### PR TITLE
Fixed rounding error in currency handling

### DIFF
--- a/norskfaktura/common.py
+++ b/norskfaktura/common.py
@@ -36,7 +36,7 @@ def pad_zeroes(n, padding):
 def str_to_money(string):
     """Takes a number, with or without a decimal point, and converts it to money"""
     string = string.replace(",",".")
-    return int(float(string)*100)
+    return int(round(float(string)*100))
 
 
 def money_to_str(integer):


### PR DESCRIPTION
Tall som ikke representeres eksakt som binære flyttall ble i noen tilfeller avrundet feil.

F.eks. vil `int(float('9.70')*100)` gi `969`, i stedet for `970` som er forventet.

Med en ekstra `round()` før kallet til `int()` håndteres dette riktig.

Takk for et genialt fakturaprogram!